### PR TITLE
live() depreciated in jQuery 1.7, removed in 1.9

### DIFF
--- a/javascript/CouponModifierField.js
+++ b/javascript/CouponModifierField.js
@@ -1,6 +1,6 @@
 (function($) {
 	$(document).ready(function() {
-		$('#apply-coupon-js').live('click', function() {
+		$( document ).on( 'click', $('#apply-coupon-js'), function() {
 
 			$('.order-form').entwine('sws').updateCart();
 


### PR DESCRIPTION
This is untested, but should work on newer versions of jQuery.
